### PR TITLE
User Story #4: Login as a Registered Account

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "body-parser": "1.20.2",
         "dotenv": "16.4.5",
         "express": "4.19.2",
-        "firebase": "10.11.1",
+        "firebase": "^10.11.1",
         "nodemon": "3.1.0",
         "socket.io": "4.7.5",
         "socket.io-client": "4.7.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "body-parser": "1.20.2",
     "dotenv": "16.4.5",
     "express": "4.19.2",
-    "firebase": "10.11.1",
+    "firebase": "^10.11.1",
     "nodemon": "3.1.0",
     "socket.io": "4.7.5",
     "socket.io-client": "4.7.5",

--- a/public/scripts/classes/firebase.js
+++ b/public/scripts/classes/firebase.js
@@ -80,6 +80,7 @@ const redirect = (req, res) => {
     res.redirect(req.baseUrl + '/lobby');
 };
 
+// Function to monitor the authentication state/ if a user is logged in or out
 const monitorAuthState = (req, res) => {
     onAuthStateChanged(auth, user => {
         if(user){
@@ -111,6 +112,22 @@ async function addUserToDB(myEmail, myUsername) {
     }
 }
 
+// Function to login with email and password
+const loginEmailPassword = async(myEmail, myPassword, req, res) => {
+    const loginEmail = myEmail;
+    const loginPassword = myPassword;
+
+    try {
+        const userCredential = await signInWithEmailAndPassword(auth, loginEmail, loginPassword);
+        console.log('User has logged in');
+        monitorAuthState(req, res);
+    } catch (error) {
+        console.log('There was an error logging in');
+        console.log(error);
+    }
+}
+
 module.exports = {
     createNewAccount,
+    loginEmailPassword
 };

--- a/server.js
+++ b/server.js
@@ -115,6 +115,13 @@ app.post('/api/signup', function (req, res) {
     createNewAccount(req.body.signupEmail, req.body.signupUsername, req.body.signupPassword, req, res);
 })
 
+// Route for logging in a user
+const {loginEmailPassword} = require('./public/scripts/classes/firebase');
+
+app.post('/api/login', function (req, res) {
+    loginEmailPassword(req.body.loginEmail, req.body.loginPassword, req, res)
+})
+
 const PORT = process.env.PORT || 3000;
 server.listen(PORT, () => {
     console.log(`Server is Running on Port ${PORT}`);

--- a/src/views/account.html
+++ b/src/views/account.html
@@ -33,15 +33,15 @@
             <div class="form login">
                 <span class="title">Login</span>
                 <!-- Login form fields -->
-                <form action="#">
+                <form action="api/login" method="post">
                     <!-- Username input field -->
                     <div class="input-field">
-                        <input type="text" placeholder="Enter your username" required>
+                        <input type="text" id="loginEmail" name="loginEmail" placeholder="Enter your username" required>
                         <i class="uil uil-user icon"></i>
                     </div>
                     <!-- Password input field -->
                     <div class="input-field">
-                        <input type="password" class="password" placeholder="Enter your password" required>
+                        <input type="password" id="loginPassword" name="loginPassword" class="password" placeholder="Enter your password" required>
                         <i class="uil uil-lock icon"></i>
                         <!-- Icon to show/hide password -->
                         <i class="uil uil-eye-slash showHidePassword"></i>

--- a/tests/firebase.test.js
+++ b/tests/firebase.test.js
@@ -12,3 +12,15 @@ test('Signup fields can be filled', async ({ page }) => {
     await page.fill('input[placeholder="Create a password"]', 'alexalex');
     await page.fill('input[placeholder="Confirm a password"]', 'alexalex');
 });
+
+test('Login redirects user to lobby', async ({ page }) => {
+    await page.goto('http://localhost:3000/account');
+    // Check if the signup form is active
+    //await expect(page.$('.account-container.active .login')).resolves.toBeTruthy();
+    // Fill the signup fields with test data
+    await page.fill('input[placeholder="Enter your username"]', 'alex@minecraft.test');
+    await page.fill('input[placeholder="Enter your password"]', 'alexalex');
+    await page.getByRole('button', { name: 'Login' }).click();
+
+    expect(page.url()).toContain('/lobby');
+});


### PR DESCRIPTION
This pull request addresses User Story #4 , which focuses on allowing the user to sign into an account they have already registered with during the signup process. Any username or password pair that has been added to the database may be used to login. On successful login, the player is redirected to the Lobby screen to allow them to join a lobby.

Note:
Please review the changes and provide any feedback or suggestions for improvement.