### PR TITLE
User Story #35: View a tool selection box.

### DIFF
--- a/public/css/draw.css
+++ b/public/css/draw.css
@@ -48,11 +48,11 @@
 }
 
 /* CSS for the drawing canvas */
-.drawing-canvas {
+.canvas-container .drawing-canvas {
     border-radius: 10px;
     box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.1);
-    height: 100%; /* Adjust as needed */
-    width: 100%; /* Adjust as needed */
+    height: 75vh;
+    width: 65vw;
 }
 
 /* CSS for the rows inside the tool box */

--- a/public/css/draw.css
+++ b/public/css/draw.css
@@ -1,22 +1,79 @@
-/* The .canvas-container class is applied to the container that wraps the title and the canvas. */
-.canvas-container {
-    align-items: center;
-    border-radius: 8px;
+/* CSS for the layout */
+.flex-container {
     display: flex;
-    flex-direction: column;
-    justify-content: center;
-    margin: 5vh auto;
 }
 
-/* The .title-drawing class applies styles to the title. */
-.canvas-container .title-drawing{
-    margin: 5vh auto;
-}
-
-/* The .drawing-canvas class applies styles to the canvas. */
-.canvas-container .drawing-canvas {
+/* CSS for the tool box */
+.tool-box {
+    background: white;
     border-radius: 10px;
     box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.1);
+    flex: none;
+    height: auto;
+    margin-right: 1%;
+    margin-top: 0%;
+    padding-right: 10px;
+    width: 10vw;
+}
+
+/* CSS for the canvas container */
+.canvas-container {
+    background: white;
+    border-radius: 10px;
+    box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.1);
+    flex: none;
     height: 75vh;
+    margin-right: 1%;
+    margin-top: 0%;
     width: 65vw;
+    float: left; /* Float the tool box to the left */
+}
+
+/* CSS for the headings */
+.title-drawing {
+    font-size: 27px;
+    font-weight: 600;
+    position: relative;
+}
+
+.title-drawing::before {
+    background-color: #003167;
+    border-radius: 25px;
+    bottom: 0;
+    content: '';
+    height: 3px;
+    left: 0;
+    position: absolute;
+    width: 30px;
+}
+
+/* CSS for the drawing canvas */
+.drawing-canvas {
+    border-radius: 10px;
+    box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.1);
+    height: 100%; /* Adjust as needed */
+    width: 100%; /* Adjust as needed */
+}
+
+/* CSS for the rows inside the tool box */
+.tool-box .row {
+    cursor: pointer;
+    margin-left: 10%; /* Adjust as needed */
+    margin-top: 10%;
+}
+
+/* CSS for the options list */
+.row .options {
+    flex-direction: column;
+    list-style: none;
+    padding: 1%; /* Use em for padding */
+    font-size: 18px;
+}
+
+/* CSS for options list and color options */
+.color-options li,
+.options li {
+    margin-bottom: 5%;
+    margin-right: 5%;
+    padding-bottom: 15px;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -18,6 +18,10 @@ body {
     padding: 0;
 }
 
+.draw-body{
+    flex-direction: row;
+}
+
 /* Graident Background */
 
 @-webkit-keyframes gradientBackground {
@@ -106,6 +110,15 @@ body {
     border: 2px solid #003167;
     background-color: #a6a6a6;
     margin-top: 15px;
+    text-align: center;
+    width: 100%;
+}
+
+.draw-button {
+    border: 2px solid #003167;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    padding: 10px 10px;
     text-align: center;
     width: 100%;
 }

--- a/src/views/draw.html
+++ b/src/views/draw.html
@@ -3,16 +3,48 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="/css/draw.css">
+    <title id="titleDrawing">Draw - Miscommunication Mayhem</title>
+    <!-- Custom CSS -->
     <link rel="stylesheet" href="/css/main.css">
-    <title id = "titleDrawing"> Draw - Miscommunication Mayhem</title>
+    <link rel="stylesheet" href="/css/draw.css">
+    <!-- Unicons CSS -->
+    <link rel="stylesheet" href="https://unicons.iconscout.com/release/v4.0.0/css/line.css">
 </head>
-<body class="body">
-    <div class = 'canvas-container'>
-        <h1 id = "title-drawing">Miscommunication Mayhem</h1>
-        <canvas class = 'drawing-canvas' id="drawing-canvas"></canvas>
+<body class="body draw-body">
+    <div class="flex-container">
+        <div class='tool-box' id='tool-box'>
+            <div class='row'>
+                <label class='title-drawing'>Tool Selection</label>
+                <ul class='options'>
+                    <!-- Tool option -->
+                    <li class='tool-option' id="tool-option-1">
+                        <i class="uil uil-pen"></i>
+                        <span>Option 1</span>
+                    </li>
+
+                    <!-- Tool option -->
+                    <li class='tool-option' id="tool-option-2">
+                        <i class="uil uil-edit"></i>
+                        <span>Option 2</span>
+                    </li>
+
+                    <!-- Button option -->
+                    <li class='tool-option'>
+                        <button class='button draw-button' id='clear-canvas-button'>Button 1</button>
+                    </li>
+
+                    <!-- Button option -->
+                    <li class='tool-option'>
+                        <button class='button draw-button' id='clear-canvas-button'>Button 2</button>
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div class='canvas-container'>
+            <canvas class='drawing-canvas' id="drawing-canvas"></canvas>
+        </div>
     </div>
-    
+
     <script src="/scripts/classes/draw.js"></script>
 </body>
 </html>

--- a/tests/draw.test.js
+++ b/tests/draw.test.js
@@ -2,16 +2,29 @@ import { test, expect } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
 
-test('Ensure the title of the drawing page is visible', async ({ page }) => {
-  await page.goto('http://localhost:3000/draw');
-  await expect(page.getByRole('heading', { name: 'Miscommunication Mayhem' })).toBeVisible();
-});
-
 test('Ensure the canvas of the drawing page is visible', async ({ page }) => {
   await page.goto('http://localhost:3000/draw');
   await expect(page.locator('#drawing-canvas')).toBeVisible();
 });
 
+// Test to ensure the toolbox heading is visible
+test("Ensure toolbox heading is visible", async ({ page }) => {
+  await page.goto('http://localhost:3000/draw');
+  await expect(page.getByText('Tool Selection')).toBeVisible();
+});
+
+
+// Test to ensure the toolbox is visible
+test('Ensure the toolbox is visible', async ({ page }) => {
+  await page.goto('http://localhost:3000/draw');
+  await expect(page.locator('#tool-box')).toBeVisible();
+});
+
+// Test to ensure a toolbox option is visible
+test("Ensure toolbox tool is visible", async ({ page }) => {
+  await page.goto('http://localhost:3000/draw');
+  await expect(page.getByText('Option 1')).toBeVisible();
+});
 
 test('Ensure canvas has correct dimensions', async ({ page }) => {
   await page.goto('http://localhost:3000/draw');


### PR DESCRIPTION
This pull request addresses User Story #35 (Part of Epic #40), which focuses on displaying a toolbox on the drawing screen. I've added mock lists that can be replaced to as "Pen" and "Eraser" for #36 and #37. I've also added mock buttons that will be used later on in future sprints for actions such as 'Undo' etc. 

Note:
Please review the changes and provide any feedback or suggestions for improvement.