### PR TITLE
User Story #51: Be Notified that a Player is Drawing/Entering a Prompt

### DIFF
--- a/public/scripts/classes/client.js
+++ b/public/scripts/classes/client.js
@@ -106,7 +106,8 @@ socket.on('game-started', (data) => {
     gameStarted = true;
     screenManager.updateRemainingUsernames(data.remainingUsernames);
     console.log(data)
-    screenManager.switchingGameScreen({gameState:data.gameState,numberOfTurns:data.numberOfTurns});
+    screenManager.switchingGameScreen({gameState:data.gameState,numberOfTurns:data.numberOfTurns,
+        currentRoundPlayer: data.currentRoundPlayer, currentRoundRole: data.currentRoundRole});
 });
 
 socket.on('cannot-start-game', () => {
@@ -128,7 +129,8 @@ socket.on('gameplay-loop', data => {
 
 // For now players will get a waiting screen
 socket.on('switch-screen-waiting', data =>{
-    screenManager.switchingGameScreen({gameState:data.gameState,numberOfTurns:data.numberOfTurns});
+    screenManager.switchingGameScreen({gameState:data.gameState,numberOfTurns:data.numberOfTurns,
+        currentRoundPlayer: data.currentRoundPlayer, currentRoundRole: data.currentRoundRole});
 });
 
 socket.on('return-lobby', data =>{

--- a/public/scripts/classes/game.js
+++ b/public/scripts/classes/game.js
@@ -209,7 +209,8 @@ function switchingGameScreen(data)
     }
     else if(data.gameState == 'waiting')
     {
-        switchToWaitingScreen({numberOfTurns:data.numberOfTurns});
+        switchToWaitingScreen({numberOfTurns:data.numberOfTurns, currentRoundPlayer:data.currentRoundPlayer, 
+            currentRoundRole:data.currentRoundRole});
     }
     else{
         endGame();
@@ -239,9 +240,27 @@ function switchToWaitingScreen(data){
     document.getElementById("intialPromptScreen").style.display = 'none'; 
     document.getElementById("guessingScreen").style.display = 'none'; 
     document.getElementById("waitingScreen").style.display = 'flex'; //Show the waiting screen
-    document.getElementById("waiting-screen-title").innerHTML = data.numberOfTurns;
-
+    document.getElementById("turnIndicatorMessage").innerHTML = data.numberOfTurns;
+    displayCurrentRoundMessage(data);
     blockAutoButtonPresses();
+}
+
+function displayCurrentRoundMessage(data){
+    document.getElementById("currentRoundMessage").innerHTML = "";
+
+    switch(data.currentRoundRole) {
+        case 'promptEntry':
+            document.getElementById("currentRoundMessage").innerHTML =  `${data.currentRoundPlayer} is prompting.` ;
+            break;
+        case 'promptEntryToDrawing':
+            document.getElementById("currentRoundMessage").innerHTML = `${data.currentRoundPlayer} is describing a drawing.` ;
+            break;
+        case 'drawing':
+            document.getElementById("currentRoundMessage").innerHTML = `${data.currentRoundPlayer} is drawing.` ;
+            break;
+        default:
+            break;
+    }
 }
 
 // Switch to the screen that the player will enter a prompt based on a provided drawing from data.drawing drawn in an image from canvas data

--- a/socket.js
+++ b/socket.js
@@ -256,12 +256,15 @@ const serverLogic = (io, userNames, rooms) => {
                 // Emit to the rest of the players that they need to go to the waiting screen and information about how many turns till end of game and their turn
                 if(room.turn < room.players.size){
                     for(let i = 0; i < room.players.size; i++){
-                            if(i != room.turn){
-                            let message =  "Waiting for ";
+                        if(i != room.turn){
+                            let message =  "";
                             let numberOfTurns = 0; 
-                            if(i > room.turn){numberOfTurns = i - room.turn; message = message + numberOfTurns + " players turn until your turn"}
-                            else{numberOfTurns = room.players.size - room.turn; message = message + numberOfTurns + " players turns until End of Game"}
-                            io.to(players[room.playerOrder[i]]).emit("switch-screen-waiting",{gameState:GameState.WAITING,numberOfTurns: message});
+                            let currentRoundRole = room.roles[room.turn]; 
+                            let currentRoundPlayer = room.players.get(players[room.playerOrder[room.turn]]);
+
+                            if(i > room.turn){numberOfTurns = i - room.turn; message = `${numberOfTurns} round(s) until your turn.`}
+                            else{numberOfTurns = room.players.size - room.turn; message = `${numberOfTurns}  round(s) until the end of the game.`}
+                            io.to(players[room.playerOrder[i]]).emit("switch-screen-waiting",{gameState:GameState.WAITING,numberOfTurns: message, currentRoundRole:currentRoundRole, currentRoundPlayer:currentRoundPlayer});
                         }
                     }
                 }
@@ -296,13 +299,15 @@ const serverLogic = (io, userNames, rooms) => {
 
                 // Loop through all players and provide the required intial emits to switch specific players to their corresponding screens 
                 for(let i = 0; i < players.length; i++) {
-                    if(i != room.turn)
-                    {
-                        let message =  "Waiting for ";
-                        let numberOfTurns = 0; 
-                        if(i > room.turn){numberOfTurns = i - room.turn; message = message + numberOfTurns + " players turn until your turn"}
+                    if(i != room.turn){
+                        let message =  "";
+                        let numberOfTurns = 0;
+                        let currentRoundRole = room.roles[room.turn]; 
+                        let currentRoundPlayer = room.players.get(players[room.playerOrder[room.turn]]);
+
+                        if(i > room.turn){numberOfTurns = i - room.turn; message = `${numberOfTurns} round(s) until your turn.`}
                         // Rest of the players are assinged the waiting screen as it is not their turn. 
-                        io.to(players[room.playerOrder[i]]).emit("game-started",{gameState:GameState.WAITING,remainingUsernames:remainingUsernames,numberOfTurns: message});
+                        io.to(players[room.playerOrder[i]]).emit("game-started",{gameState:GameState.WAITING,remainingUsernames:remainingUsernames,numberOfTurns: message, currentRoundPlayer:currentRoundPlayer, currentRoundRole:currentRoundRole});
                     }
                 }
                 
@@ -368,11 +373,14 @@ const serverLogic = (io, userNames, rooms) => {
                         if(i != room.turn)
                         {
                             console.log(players[i] + " Going to waiting screen");
-                            let message =  "Waiting for ";
+                            let message = "";
                             let numberOfTurns = 0; 
-                            if(i > room.turn){numberOfTurns = i - room.turn; message = message + numberOfTurns + " players turn until your turn"}
-                            else{numberOfTurns = room.players.size - room.turn; message = message + numberOfTurns + " players turns until End of Game"}
-                            io.to(players[room.playerOrder[i]]).emit("switch-screen-waiting",{gameState:GameState.WAITING,numberOfTurns: message});
+                            let currentRoundRole = room.roles[room.turn]; 
+                            let currentRoundPlayer = room.players.get(players[room.playerOrder[room.turn]]);
+
+                            if(i > room.turn){numberOfTurns = i - room.turn; message = `${numberOfTurns} round(s) until your turn.`}
+                            else{numberOfTurns = room.players.size - room.turn; message = `${numberOfTurns} round(s) until the end of the game.`}
+                            io.to(players[room.playerOrder[i]]).emit("switch-screen-waiting",{gameState:GameState.WAITING,numberOfTurns: message, currentRoundPlayer:currentRoundPlayer, currentRoundRole:currentRoundRole});
                         }
                     }
                     }

--- a/src/views/game.html
+++ b/src/views/game.html
@@ -136,7 +136,7 @@
         <dotlottie-player src="https://lottie.host/6ee573f4-c43f-4939-b753-8850ca1904e0/8i15FEz9Cv.json" 
         background="transparent" speed="1" style="width: 200px; height: 200px;" loop autoplay></dotlottie-player>
         <p class = 'title-drawing'>On Hold</p>
-        <p id = "currentRoundMessage" class="room-code-container"> '</h1>
+        <p id = "currentRoundMessage" class="lobby-container-text"> '</p>
         <p id = 'turnIndicatorMessage' class = 'room-code-container'>Waiting for another players turn to finish...</p>
     </div>
 

--- a/src/views/game.html
+++ b/src/views/game.html
@@ -136,8 +136,8 @@
         <dotlottie-player src="https://lottie.host/6ee573f4-c43f-4939-b753-8850ca1904e0/8i15FEz9Cv.json" 
         background="transparent" speed="1" style="width: 200px; height: 200px;" loop autoplay></dotlottie-player>
         <p class = 'title-drawing'>On Hold</p>
-
-        <p id = 'waiting-screen-title' class = 'room-code-container'>Waiting for another players turn to finish...</p>
+        <p id = "currentRoundMessage" class="room-code-container"> '</h1>
+        <p id = 'turnIndicatorMessage' class = 'room-code-container'>Waiting for another players turn to finish...</p>
     </div>
 
     <!-- Guessing screen -->


### PR DESCRIPTION
This pull request addresses User Story https://github.com/witseie-elen4010/2024-group-lab-001/issues/51, which focusses on providing users who are on the waiting  screen with an indication of what the current entails and who was assigned to the round. Minor refactoring was done in terms of displaying how many rounds until it is a players turn.

Note:
Tests will be completed in a future sprint once more functionality is added to lobby functionality, as this can only be tested if three players are in a lobby.
Please review the changes and provide any feedback or suggestions for improvement.