### PR TITLE
User Story #52: Option to Leave Lobby Session and Return to Lobby Management Screen

### DIFF
--- a/public/scripts/classes/game.js
+++ b/public/scripts/classes/game.js
@@ -117,7 +117,7 @@ function switchLobbyScreen(roomId, playerCount, remainingUsernames) {
 }
 
 function startGame(startgameButton,playerCount,roomId){
-    // if(playerCount<3){return};
+    if(playerCount<3){return};
     startgameButton.className = 'button lobby-button';
     startgameButton.disabled = false;
     startgameButton.addEventListener('click', () => {

--- a/public/scripts/classes/game.js
+++ b/public/scripts/classes/game.js
@@ -416,6 +416,12 @@ function endGame() {
     document.getElementById('endGameScreen').style.display = 'flex';
 
     blockAutoButtonPresses();
+
+    const returnToLobbyButton = document.getElementById("backToLobbyScreenButton");
+
+    returnToLobbyButton.addEventListener('click', function() {
+        window.location.reload();
+    });
 }
 
 export default {


### PR DESCRIPTION
This pull request addresses User Story #52 which allows a user to return to the lobby management screen after a game has ended. Here, the user can create or join a new lobby. Players from the previous lobby that do not leave remain in their lobby.

Note:
Please review the changes and provide any feedback or suggestions for improvement.
Test will be conducted on a later pull request.