### PR TITLE
User Story #71: Option to Undo a Stroke Recently Done and Clear Canvas

### DIFF
--- a/public/scripts/classes/draw.js
+++ b/public/scripts/classes/draw.js
@@ -2,7 +2,7 @@
 
 const canvas = document.getElementById('drawing-canvas');
 const undoButton = document.getElementById('undoCanvasButton');
-
+const clearButton = document.getElementById('clearCanvasButton');
 // Allow for different screen size scaling
 canvas.width = canvas.offsetWidth;  
 canvas.height = canvas.offsetHeight; 
@@ -64,6 +64,7 @@ canvas.addEventListener('mouseleave', ()=>{
 
 
 undoButton.addEventListener('click', undoDrawing);
+clearButton.addEventListener('click', clearCanvas);
 
 // Draw stroke lines when user has M1 key pressed 
 function draw(event)
@@ -184,4 +185,13 @@ function undoDrawing()
         restoreStrokes.pop();
         ctx.putImageData(restoreStrokes[index],0,0);
     }
+}
+
+//Clear the canvas 
+function clearCanvas()
+{
+    ctx.fillStyle = "white";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    restoreStrokes = [];
+    index = -1; 
 }

--- a/public/scripts/classes/draw.js
+++ b/public/scripts/classes/draw.js
@@ -1,6 +1,7 @@
 // draw.js
 
 const canvas = document.getElementById('drawing-canvas');
+const undoButton = document.getElementById('undoCanvasButton');
 
 // Allow for different screen size scaling
 canvas.width = canvas.offsetWidth;  
@@ -19,6 +20,10 @@ let lineWidth = 5;
 let drawingShape = 'round';
 let isDrawing = false;   
 let isSprayCan = false; 
+
+// Array for strokes so undo function can be utilized
+let restoreStrokes = [];
+let index = -1; 
 
 // Initialize canvas with default parameters 
 ctx.strokeStyle = drawingColor; 
@@ -39,6 +44,8 @@ canvas.addEventListener('mousedown', (event)=>{
 // Stop drawing if user releases M1 key
 canvas.addEventListener('mouseup', ()=>{
     isDrawing = false; 
+    restoreStrokes.push(ctx.getImageData(0,0,canvas.width,canvas.height));
+    index += 1;
     ctx.closePath();
 });
 
@@ -54,6 +61,9 @@ canvas.addEventListener('mouseleave', ()=>{
     isDrawing = false;
     ctx.closePath();
 });
+
+
+undoButton.addEventListener('click', undoDrawing);
 
 // Draw stroke lines when user has M1 key pressed 
 function draw(event)
@@ -159,4 +169,19 @@ function changeLineWidth(value)
 {
    lineWidth = value; 
    updateDrawingParameters();
+}
+
+//Allow for undo function
+function undoDrawing()
+{
+    if(index <= 0)
+    {
+        clearCanvas();
+    }
+    else
+    {
+        index -= 1;
+        restoreStrokes.pop();
+        ctx.putImageData(restoreStrokes[index],0,0);
+    }
 }

--- a/tests/draw.test.js
+++ b/tests/draw.test.js
@@ -294,5 +294,61 @@ test('User is able to change the size of the pen', async ({page}) => {
   } else {
     expect(drawingSize).toBe(38);
   }
+});
+
+  // Check if the undo button is visible 
+test('Undo button is visible', async ({ page }) => {
+  await page.goto('http://localhost:3000/draw');
+  await page.waitForSelector('#drawing-canvas');
+  await expect(page.locator('#undoCanvasButton')).toBeVisible();
+});
+
+
+// Check that the undo button works 
+test('Undo button will return screen back with no drawings', async ({ page }) => {
+  await page.goto('http://localhost:3000/draw');
+  await page.locator('#drawing-canvas').click({
+    position: {
+      x: 367,
+      y: 261
+    }
   });
+  await page.locator('#undoCanvasButton').click();
+  let isCanvasClear = await page.evaluate(() => {
+    const canvas = document.getElementById('drawing-canvas');
+    const ctx = canvas.getContext('2d');
+    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+    return Array.from(imageData).every((value, index) => index % 4 === 3 ? value === 255 : value === 255);
+  });
+
+  expect(isCanvasClear).toBe(true);
+});
+
+// Check if the clear button is visible 
+test('Clear button is visible', async ({ page }) => {
+  await page.goto('http://localhost:3000/draw');
+  await page.waitForSelector('#drawing-canvas');
+  await expect(page.locator('#clearCanvasButton')).toBeVisible();
+});
+
+// Check if the clear button clears the canvas 
+test('Clear button will return screen back with no drawings', async ({ page }) => {
+  await page.goto('http://localhost:3000/draw');await page.goto('http://localhost:3000/draw');
+  await page.locator('#drawing-canvas').click({
+    position: {
+      x: 367,
+      y: 261
+    }
+  });
+  await page.locator('#clearCanvasButton').click();
+  let isCanvasClear = await page.evaluate(() => {
+    const canvas = document.getElementById('drawing-canvas');
+    const ctx = canvas.getContext('2d');
+    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+    return Array.from(imageData).every((value, index) => index % 4 === 3 ? value === 255 : value === 255);
+  });
+
+  expect(isCanvasClear).toBe(true);
+});
+
 


### PR DESCRIPTION
This pull request addresses User Story https://github.com/witseie-elen4010/2024-group-lab-001/issues/71, which focusses on providing users who are drawing with the ability to undo a stroke that they have made on the drawing canvas as well as the ability to clear the entire canvas. Tests were done to test the functionality of these added features.

Note:

Please review the changes and provide any feedback or suggestions for improvement.